### PR TITLE
Setup Docker with updated dependencies and domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: Build the application
+FROM node:20-alpine as builder
+WORKDIR /app
+COPY . ./
+ENV NODE_ENV=production
+RUN yarn install --frozen-lockfile && yarn run build
+
+# Stage 2: Serve the application with unprivileged NGINX
+FROM nginxinc/nginx-unprivileged as production
+
+ARG DOCROOT=/usr/share/nginx/html
+COPY --from=builder /app/build ${DOCROOT}
+
+EXPOSE 8080

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node scripts/serve-local.js",
     "build": "node scripts/build.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
     "@rollup/plugin-babel": "^5.1.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -164,7 +164,7 @@ async function buildCss(entryPath, targetDir, assets) {
 
 async function removeDirIfExists(targetDir) {
     try {
-        await fs.rmdir(targetDir, {recursive: true});
+        await fs.rm(targetDir, { recursive: true });
     } catch (err) {
         if (err.code !== "ENOENT") {
             throw err;

--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -18,6 +18,8 @@ import {Maturity, Platform, LinkKind,
     FDroidLink, AppleStoreLink, PlayStoreLink, WebsiteLink} from "../types.js";
 
 const trustedWebInstances = [
+    "chat.blender.org",
+    "chat.staging.blender.org",
     "app.element.io",   // first one is the default one
     "develop.element.io",
     "chat.fedoraproject.org",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,9 +1134,9 @@ call-bind@^1.0.0:
     get-intrinsic "^1.0.0"
 
 caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+  version "1.0.30001651"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
+  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
 chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
- Adds `chat.blender.org` and `chat.staging.blender.org` to `trustedWebInstances`
- Update `caniuse` and move `devDependencies` to `dependencies`
- Replace deprecated use of `fs.rmdir()` with `fs.rm()`
- Create `Dockerfile` that has a build staging using `yarn` and serves the static build using `nginx-unprivileged` 